### PR TITLE
Fix bug in fpdi_bridge.php

### DIFF
--- a/fpdi_bridge.php
+++ b/fpdi_bridge.php
@@ -25,7 +25,7 @@
  * This way it is possible to use FPDI for both FPDF and TCPDF with one FPDI version.
  */
 
-if (!class_exists('TCPDF', false)) {
+if (class_exists('FPDF', false)) {
     /**
      * Class fpdi_bridge
      */


### PR DESCRIPTION
The class loader says that if `TCPDF` isn't loaded we should extend `FPDF`, but it doesn't check that `FPDF` exists. This throws a `PHP_FATAL` "Fatal error: Class 'FPDF' not found…"

This alters the check by confirming `FPDF` exists, otherwise loading `TCPDF`.