### PR TITLE
Rename of Tecnickcom tcpdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you are using TCPDF, your have to update your composer.json respectively to:
 ```json
 {
     "require": {
-        "tecnick.com/tcpdf": "6.2.8",
+        "tecnickcom/tcpdf": "6.2.12",
         "setasign/fpdi": "1.5.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ]
   },
   "suggest": {
-    "setasign/fpdf": "FPDI will extend this class but as it is also possible to use \"tecnick.com/tcpdf\" as an alternative there's no fixed dependency configured.",
+    "setasign/fpdf": "FPDI will extend this class but as it is also possible to use \"tecnickcom/tcpdf\" as an alternative there's no fixed dependency configured.",
     "setasign/fpdi-fpdf": "Use this package to automatically evaluate dependencies to FPDF.",
     "setasign/fpdi-tcpdf": "Use this package to automatically evaluate dependencies to TCPDF."
   }


### PR DESCRIPTION
See https://github.com/tecnickcom/TCPDF/commit/2f732eaa91b5665274689b1d40b285a7bacdc37f 
See also : https://packagist.org/packages/tecnick.com/tcpdf
"This package is abandoned and no longer maintained. The author suggests using the tecnickcom/tcpdf package instead." 