### PR TITLE
Fixes fseek past the end-of-file

### DIFF
--- a/pdf_context.php
+++ b/pdf_context.php
@@ -67,7 +67,13 @@ class pdf_context
     public function getPos()
     {
         if ($this->_mode == 0) {
-            return ftell($this->file);
+            $pos = ftell($this->file);
+
+            if (feof($this->file)) {
+                $pos--;
+            }
+
+            return $pos;
         } else {
             return 0;
         }


### PR DESCRIPTION
Using FPDI on Google App Engine does not work since at some points it wants to reset the file pointer past the end-of-file. Unfortunately the Google Cloud Storage stream wrapper does not support that.

From the PHP manual:

> In general, it is allowed to seek past the end-of-file; if data is then written, reads in any unwritten region between the end-of-file and the sought position will yield bytes with value 0. However, certain streams may not support this behavior, especially when they have an underlying fixed size storage.

This PR contains one possible fix for the problem, since it manifests itself in `pdf_parser::resolveObject()` when resetting the pointer to `$oldPos`.

Another solution would be to determine file size in the constructor of `pdf_context` and never allow `$pos` to be greater than `$filesize - 1` in `reset()`.

Any input on this is most welcome. Would be nice if we can get this merged / fixed somehow.