### PR TITLE
Temporary file parameter for setSourceFile

### DIFF
--- a/fpdi.php
+++ b/fpdi.php
@@ -89,7 +89,7 @@ class FPDI extends FPDF_TPL
      * @param string $filename A valid path to the PDF document from which pages should be imported from
      * @return int The number of pages in the document
      */
-    public function setSourceFile($filename)
+    public function setSourceFile($filename, $temp = false)
     {
         $_filename = realpath($filename);
         if (false !== $_filename)
@@ -115,12 +115,12 @@ class FPDI extends FPDF_TPL
      * @param string $filename
      * @return fpdi_pdf_parser
      */
-    protected function _getPdfParser($filename)
+    protected function _getPdfParser($filename, $temp = false)
     {
         if (!class_exists('fpdi_pdf_parser')) {
             require_once('fpdi_pdf_parser.php');
         }
-        return new fpdi_pdf_parser($filename);
+        return new fpdi_pdf_parser($filename, $temp);
     }
     
     /**

--- a/fpdi_pdf_parser.php
+++ b/fpdi_pdf_parser.php
@@ -59,9 +59,9 @@ class fpdi_pdf_parser extends pdf_parser
      *
      * @param string $filename The source filename
      */
-    public function __construct($filename)
+    public function __construct($filename, $temp = false)
     {
-        parent::__construct($filename);
+        parent::__construct($filename, $temp);
 
         // resolve Pages-Dictonary
         $pages = $this->resolveObject($this->_root[1][1]['/Pages']);

--- a/pdf_parser.php
+++ b/pdf_parser.php
@@ -173,11 +173,19 @@ class pdf_parser
      * @param string $filename Source filename
      * @throws InvalidArgumentException
      */
-    public function __construct($filename)
+    public function __construct($filename, $temp = false)
     {
         $this->filename = $filename;
-
-        $this->_f = @fopen($this->filename, 'rb');
+        
+        //If a tempoary file is required for reading and writing to
+        if($temp) {
+            $tempoary_file = tmpfile();
+            @fwrite($tempoary_file, file_get_contents($this->filename));
+            $this->_f = $tempoary_file;
+        } else {
+            $this->_f = @fopen($this->filename, 'rb');
+        }
+        
 
         if (!$this->_f) {
             throw new InvalidArgumentException(sprintf('Cannot open %s !', $filename));


### PR DESCRIPTION
When using Google App Engine it became apparent that this library was causing performance issues when using the import functionality. The reason for this is that the template file must be stored in a Google Storage bucket. Each time the import needed to make a read to the template file it had to make a get request. To resolve this issue I've added a temp file parameter to the setSourcefile function and recursively added to the constructs of pdf_parser

