### PR TITLE
Check parser instance in destrcut method

### DIFF
--- a/src/PdfReader/PdfReader.php
+++ b/src/PdfReader/PdfReader.php
@@ -56,8 +56,10 @@ class PdfReader
      */
     public function __destruct()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
-        $this->parser->cleanUp();
+        if ($this->parser !== null) {
+            /** @noinspection PhpInternalEntityUsedInspection */
+            $this->parser->cleanUp();
+        }
     }
 
     /**


### PR DESCRIPTION
This problem only occurs when an error during the autoload mechanism is
raised.