### PR TITLE
Added $context to __constructor

### DIFF
--- a/pdf_parser.php
+++ b/pdf_parser.php
@@ -171,13 +171,14 @@ class pdf_parser
      * Constructor
      *
      * @param string $filename Source filename
+     * @param array $$context Resource stream context
      * @throws InvalidArgumentException
      */
-    public function __construct($filename)
+    public function __construct($filename, $context = [])
     {
         $this->filename = $filename;
 
-        $this->_f = @fopen($this->filename, 'rb');
+        $this->_f = @fopen($this->filename, 'rb', false, $context);
 
         if (!$this->_f) {
             throw new InvalidArgumentException(sprintf('Cannot open %s !', $filename));


### PR DESCRIPTION
I realize this is legacy code but I am using a package that relies on it. I need to tell fopen the context of the file in order to have seekable streams. Please merge. Thanks!