### PR TITLE
Remove call to deprecated each function

### DIFF
--- a/fpdi.php
+++ b/fpdi.php
@@ -571,7 +571,7 @@ class FPDI extends FPDF_TPL
 
                 reset ($value[1]);
 
-                while (list($k, $v) = each($value[1])) {
+                foreach($value[1] as $k => $v) {
                     $this->_straightOut($k . ' ');
                     $this->_writeValue($v);
                 }


### PR DESCRIPTION
The each() function has been deprecated as of PHP 7.2, so this small change rewrites the affected code using foreach().