### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you want to use TCPDF, you have to update your composer.json to:
 ```json
 {
     "require": {
-        "tecnickcom/tcpdf": "6.2.*",
+        "tecnickcom/tcpdf": "6.3.*",
         "setasign/fpdi": "^2.0"
     }
 }


### PR DESCRIPTION
tecnickcom/tcpdf version 6.2 uses curly braces to access arrays resulting in error with php8. Version 6.3.5 fixed this.

In my configuration it was giving me the following error (code 500): Array and string offset access syntax with curly braces is deprecated.
Removing tecnickcom/tcpdf version 6.2 and installing the latest version of tcpdf (that is currently the 6.3.5) fixed it.