### PR TITLE
Access level to FPDI::_putformxobjects() must be public (as in class …

### DIFF
--- a/fpdi.php
+++ b/fpdi.php
@@ -377,7 +377,7 @@ class FPDI extends FPDF_TPL
     /**
      * Writes the form XObjects to the PDF document.
      */
-    protected function _putformxobjects()
+    public function _putformxobjects()
     {
         $filter = ($this->compress) ? '/Filter /FlateDecode ' : '';
         reset($this->_tpls);


### PR DESCRIPTION
…FPDF_TPL)