### PR TITLE
Optimized support for ignoring faulty structures in page tree

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,30 +9,30 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^0.16 || ^1",
                 "phpstan/phpstan": "^1.4",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -59,7 +59,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -75,7 +75,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1656,16 +1656,16 @@
         },
         {
             "name": "tecnickcom/tcpdf",
-            "version": "6.5.0",
+            "version": "6.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "cc54c1503685e618b23922f53635f46e87653662"
+                "reference": "e3cffc9bcbc76e89e167e9eb0bbda0cab7518459"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/cc54c1503685e618b23922f53635f46e87653662",
-                "reference": "cc54c1503685e618b23922f53635f46e87653662",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/e3cffc9bcbc76e89e167e9eb0bbda0cab7518459",
+                "reference": "e3cffc9bcbc76e89e167e9eb0bbda0cab7518459",
                 "shasum": ""
             },
             "require": {
@@ -1716,7 +1716,7 @@
             ],
             "support": {
                 "issues": "https://github.com/tecnickcom/TCPDF/issues",
-                "source": "https://github.com/tecnickcom/TCPDF/tree/6.5.0"
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.6.2"
             },
             "funding": [
                 {
@@ -1724,7 +1724,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2022-08-12T07:50:54+00:00"
+            "time": "2022-12-17T10:28:59+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/PdfReader/PdfReader.php
+++ b/src/PdfReader/PdfReader.php
@@ -202,7 +202,8 @@ class PdfReader
             return;
         }
 
-        $readPages = function ($kids, $count) use (&$readPages, $readAll) {
+        $expectedPageCount = $this->getPageCount();
+        $readPages = function ($kids, $count) use (&$readPages, $readAll, $expectedPageCount) {
             $kids = PdfArray::ensure($kids);
             $isLeaf = ($count->value === \count($kids->value));
 
@@ -221,6 +222,11 @@ class PdfReader
                     $readPages(PdfDictionary::get($object->value, 'Kids'), PdfDictionary::get($object->value, 'Count'));
                 } else {
                     $this->pages[] = $object;
+                }
+
+                // stop if all pages are read - faulty documents exists with additional entries with invalid data.
+                if (count($this->pages) === $expectedPageCount) {
+                    break;
                 }
             }
         };

--- a/tests/_files/pdfs/specials/page-trees/PageTreeWithInvalidTypeAndMisslLeadingCount.pdf
+++ b/tests/_files/pdfs/specials/page-trees/PageTreeWithInvalidTypeAndMisslLeadingCount.pdf
@@ -1,0 +1,26 @@
+%PDF-1.3
+%‚„œ”
+4 0 obj
+(Anything)
+endobj
+3 0 obj
+<</Type/Pages/Kids[ 1 0 R 4 0 R]/Count 1>>
+endobj
+2 0 obj
+<</Type/Catalog/Pages 3 0 R>>
+endobj
+1 0 obj
+<</Type/Page/MediaBox[ 0 0 595.28 841.89]/Resources<<>>/Parent 3 0 R>>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000144 00000 n 
+0000000099 00000 n 
+0000000041 00000 n 
+0000000015 00000 n 
+trailer
+<</Size 5/Root 2 0 R/ID[<4d1a51bd6a59a079d9d4aafd524163c0><4d1a51bd6a59a079d9d4aafd524163c0>]>>
+startxref
+230
+%%EOF

--- a/tests/functional/PdfReader/PdfReaderTest.php
+++ b/tests/functional/PdfReader/PdfReaderTest.php
@@ -49,6 +49,11 @@ class PdfReaderTest extends TestCase
             13
         ];
 
+        $data[] = [
+            $path . '/specials/page-trees/PageTreeWithInvalidTypeAndMisslLeadingCount.pdf',
+            1
+        ];
+
         return $data;
     }
 
@@ -830,6 +835,27 @@ class PdfReaderTest extends TestCase
                             PdfIndirectObjectReference::create(5, 0)
                         ]),
                         'Parent' => PdfIndirectObjectReference::create(9, 0),
+                    ])
+                )
+            ]
+        ];
+
+        $data[] = [
+            $path . '/specials/page-trees/PageTreeWithInvalidTypeAndMisslLeadingCount.pdf',
+            [
+                1 => PdfIndirectObject::create(
+                    1,
+                    0,
+                    PdfDictionary::create([
+                        'Type' => PdfName::create('Page'),
+                        'MediaBox' => PdfArray::create([
+                            PdfNumeric::create(0),
+                            PdfNumeric::create(0),
+                            PdfNumeric::create(595.28),
+                            PdfNumeric::create(841.89)
+                        ]),
+                        'Resources' => PdfDictionary::create(),
+                        'Parent' => PdfIndirectObjectReference::create(3, 0),
                     ])
                 )
             ]


### PR DESCRIPTION
The parsing of the page tree is stopped now as soon as the page count is reached. By doing this we can ignore following faulty objects in the Kids structure.