### PR TITLE
Fixed the deprecation of dynamic properties in PHP 8.2

### DIFF
--- a/src/FpdiTrait.php
+++ b/src/FpdiTrait.php
@@ -88,6 +88,20 @@ trait FpdiTrait
     protected $objectsToCopy = [];
 
     /**
+     * String buffer.
+     *
+     * @var string
+     */
+    protected $buffer;
+
+    /**
+     * Object number.
+     *
+     * @var int
+     */
+    protected $n;
+
+    /**
      * Release resources and file handles.
      *
      * This method is called internally when the document is created successfully. By default it only cleans up


### PR DESCRIPTION
There are two properties that need to be added:
1. $buffer is called from \Fpdi::_put() and \Fpdi\Tfpdf::_put()
2. $n called from \Fpdi::_putimages() and \Fpdi\Tfpdf::_putimages()