### PR TITLE
Ignore undefined objects in link annotation logic

### DIFF
--- a/tests/_files/pdfs/links/annotations-with-invalid-references.pdf
+++ b/tests/_files/pdfs/links/annotations-with-invalid-references.pdf
@@ -1,0 +1,30 @@
+%PDF-1.3
+%‚„œ”
+5 0 obj
+<</Type/Annot/Subtype/Link/Rect[ 140 140 100 200]/A<</S/URI/URI(https://www.setasign.com/#2)>>/Border[ 0 0 0]/BS<</S/S/W 1>>/P 1 0 R>>
+endobj
+4 0 obj
+<</Type/Annot/Subtype/Link/Rect[ 20 20 100 200]/A<</S/URI/URI(https://www.setasign.com/#1)>>/Border[ 0 0 0]/BS<</S/S/W 1>>/P 1 0 R>>
+endobj
+3 0 obj
+<</Type/Pages/Kids[ 1 0 R]/Count 1>>
+endobj
+2 0 obj
+<</Type/Catalog/Pages 3 0 R>>
+endobj
+1 0 obj
+<</Type/Page/MediaBox[ 0 0 595.28 841.89]/Resources<<>>/Parent 3 0 R/Annots[ 4 0 R 1234 0 R 5 0 R]>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000410 00000 n 
+0000000365 00000 n 
+0000000313 00000 n 
+0000000165 00000 n 
+0000000015 00000 n 
+trailer
+<</Size 6/Root 2 0 R/ID[<4418da65c9702985cc8d26e247d103dd><4418da65c9702985cc8d26e247d103dd>]>>
+startxref
+526
+%%EOF

--- a/tests/_files/pdfs/links/invalid-annots-reference.pdf
+++ b/tests/_files/pdfs/links/invalid-annots-reference.pdf
@@ -1,0 +1,22 @@
+%PDF-1.3
+%‚„œ”
+3 0 obj
+<</Type/Pages/Kids[ 1 0 R]/Count 1>>
+endobj
+2 0 obj
+<</Type/Catalog/Pages 3 0 R>>
+endobj
+1 0 obj
+<</Type/Page/MediaBox[ 0 0 595.28 841.89]/Resources<<>>/Parent 3 0 R/Annots 1234 0 R>>
+endobj
+xref
+0 4
+0000000000 65535 f 
+0000000112 00000 n 
+0000000067 00000 n 
+0000000015 00000 n 
+trailer
+<</Size 4/Root 2 0 R/ID[<98300914e840964a78dc6bb2a5801d0d><98300914e840964a78dc6bb2a5801d0d>]>>
+startxref
+214
+%%EOF

--- a/tests/functional/PdfReader/PageTest.php
+++ b/tests/functional/PdfReader/PageTest.php
@@ -71,6 +71,27 @@ class PageTest extends TestCase
                         ]
                     ]
                 ]
+            ],
+            [
+                __DIR__ . '/../../_files/pdfs/links/annotations-with-invalid-references.pdf',
+                [
+                    1 => [
+                        [
+                            'uri' => 'https://www.setasign.com/#1',
+                            'rect' => new Rectangle(20, 20, 100, 200)
+                        ],
+                        [
+                            'uri' => 'https://www.setasign.com/#2',
+                            'rect' => new Rectangle(140, 140, 100, 200)
+                        ]
+                    ]
+                ]
+            ],
+            [
+                __DIR__ . '/../../_files/pdfs/links/invalid-annots-reference.pdf',
+                [
+                    1 => []
+                ]
             ]
         ];
     }


### PR DESCRIPTION
This PR ignores fault/undefined object references when resolving annotations.