### PR TITLE
Remove implicitly nullable parameter declarations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
 	level: 5
+	treatPhpDocTypesAsCertain: false
 	paths:
 		- src
 		#- tests

--- a/src/GraphicsState.php
+++ b/src/GraphicsState.php
@@ -30,7 +30,9 @@ class GraphicsState
     {
         if ($ctm === null) {
             $ctm = new Matrix();
-        }
+        } elseif (!($ctm instanceof Matrix)) {
+			throw new \InvalidArgumentException('$ctm must be an instance of Fpdi\\Matrix or null');
+		}
 
         $this->ctm = $ctm;
     }

--- a/src/GraphicsState.php
+++ b/src/GraphicsState.php
@@ -31,8 +31,8 @@ class GraphicsState
         if ($ctm === null) {
             $ctm = new Matrix();
         } elseif (!($ctm instanceof Matrix)) {
-			throw new \InvalidArgumentException('$ctm must be an instance of Fpdi\\Matrix or null');
-		}
+            throw new \InvalidArgumentException('$ctm must be an instance of Fpdi\\Matrix or null');
+        }
 
         $this->ctm = $ctm;
     }

--- a/src/GraphicsState.php
+++ b/src/GraphicsState.php
@@ -26,7 +26,7 @@ class GraphicsState
     /**
      * @param Matrix|null $ctm
      */
-    public function __construct(Matrix $ctm = null)
+    public function __construct($ctm = null)
     {
         if ($ctm === null) {
             $ctm = new Matrix();

--- a/src/PdfParser/Type/PdfDictionary.php
+++ b/src/PdfParser/Type/PdfDictionary.php
@@ -107,7 +107,7 @@ class PdfDictionary extends PdfType
      * @return PdfNull|PdfType
      * @throws PdfTypeException
      */
-    public static function get($dictionary, $key, PdfType $default = null)
+    public static function get($dictionary, $key, $default = null)
     {
         $dictionary = self::ensure($dictionary);
 

--- a/src/PdfParser/Type/PdfDictionary.php
+++ b/src/PdfParser/Type/PdfDictionary.php
@@ -109,6 +109,9 @@ class PdfDictionary extends PdfType
      */
     public static function get($dictionary, $key, $default = null)
     {
+		if ($default !== null && !($default instanceof PdfType)) {
+			throw new \InvalidArgumentException('Default value must be an instance of PdfType or null');
+		}
         $dictionary = self::ensure($dictionary);
 
         if (isset($dictionary->value[$key])) {

--- a/src/PdfParser/Type/PdfDictionary.php
+++ b/src/PdfParser/Type/PdfDictionary.php
@@ -109,9 +109,9 @@ class PdfDictionary extends PdfType
      */
     public static function get($dictionary, $key, $default = null)
     {
-		if ($default !== null && !($default instanceof PdfType)) {
-			throw new \InvalidArgumentException('Default value must be an instance of PdfType or null');
-		}
+        if ($default !== null && !($default instanceof PdfType)) {
+            throw new \InvalidArgumentException('Default value must be an instance of PdfType or null');
+        }
         $dictionary = self::ensure($dictionary);
 
         if (isset($dictionary->value[$key])) {

--- a/src/PdfParser/Type/PdfStream.php
+++ b/src/PdfParser/Type/PdfStream.php
@@ -37,6 +37,9 @@ class PdfStream extends PdfType
      */
     public static function parse(PdfDictionary $dictionary, StreamReader $reader, $parser = null)
     {
+		if ($parser !== null && !($parser instanceof PdfParser)) {
+			throw new \InvalidArgumentException('$parser must be an instance of PdfParser or null');
+		}
         $v = new self();
         $v->value = $dictionary;
         $v->reader = $reader;

--- a/src/PdfParser/Type/PdfStream.php
+++ b/src/PdfParser/Type/PdfStream.php
@@ -37,9 +37,9 @@ class PdfStream extends PdfType
      */
     public static function parse(PdfDictionary $dictionary, StreamReader $reader, $parser = null)
     {
-		if ($parser !== null && !($parser instanceof PdfParser)) {
-			throw new \InvalidArgumentException('$parser must be an instance of PdfParser or null');
-		}
+        if ($parser !== null && !($parser instanceof PdfParser)) {
+            throw new \InvalidArgumentException('$parser must be an instance of PdfParser or null');
+        }
         $v = new self();
         $v->value = $dictionary;
         $v->reader = $reader;

--- a/src/PdfParser/Type/PdfStream.php
+++ b/src/PdfParser/Type/PdfStream.php
@@ -31,11 +31,11 @@ class PdfStream extends PdfType
      *
      * @param PdfDictionary $dictionary
      * @param StreamReader $reader
-     * @param PdfParser $parser Optional to keep backwards compatibility
+     * @param PdfParser|null $parser Optional to keep backwards compatibility
      * @return self
      * @throws PdfTypeException
      */
-    public static function parse(PdfDictionary $dictionary, StreamReader $reader, PdfParser $parser = null)
+    public static function parse(PdfDictionary $dictionary, StreamReader $reader, $parser = null)
     {
         $v = new self();
         $v->value = $dictionary;


### PR DESCRIPTION
Implicitly nullable parameter declarations are [deprecated from PHP 8.4 on](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) and will be removed in PHP 9. This PR removes all nullable declarations to keep the code compatible with future PHP versions, with no impact on backward compatibility. 

As an alternative to dropping declarations, we could use declarations of the form `(?Matrix $ctm = null)`, but then we would lose compatibility with PHP before 7.1. 

How to reproduce the issues:
```
> docker run --rm -v .:/app "php:8.4-rc-cli" find /app -type f -name "*.php" -exec php -d error_reporting=32765 -l {} \; | grep -v 'No syntax errors detected'
Deprecated: setasign\Fpdi\GraphicsState::__construct(): Implicitly marking parameter $ctm as nullable is deprecated, the explicit nullable type must be used instead in /app/src/GraphicsState.php on line 29
Deprecated: setasign\Fpdi\PdfParser\Type\PdfStream::parse(): Implicitly marking parameter $parser as nullable is deprecated, the explicit nullable type must be used instead in /app/src/PdfParser/Type/PdfStream.php on line 38
Deprecated: setasign\Fpdi\PdfParser\Type\PdfDictionary::get(): Implicitly marking parameter $default as nullable is deprecated, the explicit nullable type must be used instead in /app/src/PdfParser/Type/PdfDictionary.php on line 110
```
With the patches from this PR, the deprecation warnings are gone.