### PR TITLE
Bugfix - Type resolve missing for nested pages in structure

### DIFF
--- a/src/PdfReader/PdfReader.php
+++ b/src/PdfReader/PdfReader.php
@@ -219,7 +219,10 @@ class PdfReader
                 $type = PdfDictionary::get($object->value, 'Type');
 
                 if ($type->value === 'Pages') {
-                    $readPages(PdfDictionary::get($object->value, 'Kids'), PdfDictionary::get($object->value, 'Count'));
+                    $readPages(
+                        PdfType::resolve(PdfDictionary::get($object->value, 'Kids'), $this->parser),
+                        PdfType::resolve(PdfDictionary::get($object->value, 'Count'), $this->parser)
+                    );
                 } else {
                     $this->pages[] = $object;
                 }


### PR DESCRIPTION
I found a bug in the code when working with PDF files that have a complex nested page structure.
<details>
  <summary>Screenshot of an example structure</summary>

>   **On the left** is a complex structure that causes an error
>   **On the right** is a normal one

  ![pdf-complex-nested](https://github.com/user-attachments/assets/5b85cca5-5c2e-4be4-a6db-554d0685eacd)
</details>


Which caused the following error:
`Fatal error: Uncaught exception 'setasign\Fpdi\PdfParser\Type\PdfTypeException' with message 'Array value expected.'`

The proposed commit fixes this bug.

