### PR TITLE
chore: Increase minimum version of tecnickcom/tcpdf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7",
         "setasign/fpdf": "~1.8.6",
-        "tecnickcom/tcpdf": "^6.2",
+        "tecnickcom/tcpdf": "^6.8",
         "setasign/tfpdf": "~1.33",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e9aa3c72fdbdd3d1b5977341757d7fe",
+    "content-hash": "b92a263a1492043f7f4eef64898cb64c",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
hey there :wave: 

according to [packagist](https://packagist.org/packages/tecnickcom/tcpdf) the versions of `tecnickcom/tcpdf` below 6.8.0 have security advisories. 
Therefore the minimum version should be increased in the `composer.json`. This will help for fix test cases where `composer update --prefer-lowest` is executed. As the package is already locked to `6.8.2` this should not be an issue. 

Best regards :v: 